### PR TITLE
[DIGI-12658] Feature/sdkagent new format

### DIFF
--- a/digime-core/src/main/java/me/digi/sdk/core/CAContract.java
+++ b/digime-core/src/main/java/me/digi/sdk/core/CAContract.java
@@ -14,6 +14,7 @@ import com.google.gson.annotations.SerializedName;
 import java.io.Serializable;
 
 import me.digi.sdk.core.entities.DataRequest;
+import me.digi.sdk.core.entities.SDKAgent;
 
 public class CAContract implements Parcelable {
 
@@ -29,6 +30,9 @@ public class CAContract implements Parcelable {
 
     @SerializedName("accept")
     public AcceptData accept;
+
+    @SerializedName("sdkAgent")
+    public SDKAgent sdkAgent = new SDKAgent();
 
     public static final Parcelable.Creator<CAContract> CREATOR
             = new Parcelable.Creator<CAContract>() {

--- a/digime-core/src/main/java/me/digi/sdk/core/config/ApiConfig.java
+++ b/digime-core/src/main/java/me/digi/sdk/core/config/ApiConfig.java
@@ -14,6 +14,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import me.digi.sdk.core.BuildConfig;
+import me.digi.sdk.core.errorhandling.DigiMeException;
 import okhttp3.HttpUrl;
 
 public final class ApiConfig {
@@ -44,18 +45,22 @@ public final class ApiConfig {
         return url.host();
     }
 
-    public String userAgentString(String appName, String versionCode) {
-        StringBuilder sb = new StringBuilder();
-        sb.append(appName);
-
+    public static String parseVersion(String versionCode) {
         Pattern pattern = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)");
         Matcher matcher = pattern.matcher(versionCode);
-        if (matcher.lookingAt()) {
-            sb.append("/")
-                .append(matcher.group());
-        }
+        if (matcher.lookingAt())
+            return matcher.group();
+        else
+            throw new DigiMeException("Failed to parse valid version String from: "+versionCode);
+    }
 
-        sb.append(" (" + Build.MODEL + "; " +
+    /** Currently no validation checks on this, can be what we like. {@link me.digi.sdk.core.entities.SDKAgent} IS validated however */
+    public String userAgentString(String appName, String versionCode) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(appName)
+        .append("/")
+        .append(parseVersion(versionCode))
+        .append(" (" + Build.MODEL + "; " +
             "Android; " +
             Build.VERSION.RELEASE + ')');
 

--- a/digime-core/src/main/java/me/digi/sdk/core/entities/SDKAgent.java
+++ b/digime-core/src/main/java/me/digi/sdk/core/entities/SDKAgent.java
@@ -7,15 +7,11 @@ import android.os.Build;
 
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
-import java.io.Serializable;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import me.digi.sdk.core.DigiMeSDKVersion;
-import me.digi.sdk.core.errorhandling.DigiMeException;
+import me.digi.sdk.core.config.ApiConfig;
 
-
-public class SDKAgent implements Serializable {
+// Validation spec: https://digi-me.atlassian.net/wiki/spaces/ENG/pages/394002569/CA+SDK+Compatibility
+public class SDKAgent {
 
     @SerializedName("name")
     public final String platform;
@@ -25,24 +21,19 @@ public class SDKAgent implements Serializable {
 
     // anything else that may be useful
     @SerializedName("meta")
-    public String metaJson;
+    public JsonObject meta;
 
     public SDKAgent() {
         platform = "android";
-        version = parseVersion(DigiMeSDKVersion.VERSION);
+        version = ApiConfig.parseVersion(DigiMeSDKVersion.VERSION);
+        meta = createMeta();
+    }
+
+    private static JsonObject createMeta() {
         JsonObject jsonObject = new JsonObject();
         jsonObject.addProperty("device", Build.MODEL);
         jsonObject.addProperty("osVersion", Build.VERSION.RELEASE);
-        metaJson = jsonObject.toString();
-    }
-
-    private String parseVersion(String versionCode) {
-        Pattern pattern = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)");
-        Matcher matcher = pattern.matcher(versionCode);
-        if (matcher.lookingAt())
-            return matcher.group();
-        else
-            throw new DigiMeException("Failed to parse valid version String from: "+versionCode);
+        return jsonObject;
     }
 
 }

--- a/digime-core/src/main/java/me/digi/sdk/core/entities/SDKAgent.java
+++ b/digime-core/src/main/java/me/digi/sdk/core/entities/SDKAgent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2009-2018 digi.me Limited. All rights reserved.
+ */
+package me.digi.sdk.core.entities;
+
+import android.os.Build;
+
+import com.google.gson.JsonObject;
+import com.google.gson.annotations.SerializedName;
+import java.io.Serializable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import me.digi.sdk.core.DigiMeSDKVersion;
+import me.digi.sdk.core.errorhandling.DigiMeException;
+
+
+public class SDKAgent implements Serializable {
+
+    @SerializedName("name")
+    public final String platform;
+
+    @SerializedName("version")
+    public String version;
+
+    // anything else that may be useful
+    @SerializedName("meta")
+    public String metaJson;
+
+    public SDKAgent() {
+        platform = "android";
+        version = parseVersion(DigiMeSDKVersion.VERSION);
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("device", Build.MODEL);
+        jsonObject.addProperty("osVersion", Build.VERSION.RELEASE);
+        metaJson = jsonObject.toString();
+    }
+
+    private String parseVersion(String versionCode) {
+        Pattern pattern = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)");
+        Matcher matcher = pattern.matcher(versionCode);
+        if (matcher.lookingAt())
+            return matcher.group();
+        else
+            throw new DigiMeException("Failed to parse valid version String from: "+versionCode);
+    }
+
+}


### PR DESCRIPTION
Note previously we had wrongly interpreted the spec as referring to the User-Agent header, but that is separate (and has no validation associated with it). Thankfully a further change in spec made it clearer and I realised the mistake! Have tested this after back end deployment